### PR TITLE
Bump to GNOME 49

### DIFF
--- a/com.cassidyjames.butler.json
+++ b/com.cassidyjames.butler.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.cassidyjames.butler",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "49",
   "sdk": "org.gnome.Sdk",
   "command": "com.cassidyjames.butler",
   "finish-args": [


### PR DESCRIPTION
When I run a flatpak update I get a message - The GNOME 47 runtime is no longer supported as of October 15, 2025. Please ask your application developer to migrate to a supported platform.
